### PR TITLE
docs: Correct certificate file name mismatch in windows setup sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ To learn more about these steps, see [action.yml](action.yml).
 steps:
   - name: Setup SM_CLIENT_CERT_FILE from base64 secret data
     run: |
-      echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/sm_client_cert.p12
+      echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
       shell: bash
   - name: Setup Software Trust Manager
     uses: digicert/code-signing-software-trust-action@v1
+    env:
       SM_HOST: ${{ vars.SM_HOST }}
       SM_API_KEY: ${{ secrets.SM_API_KEY }}
       SM_CLIENT_CERT_FILE: D:\\Certificate_pkcs12.p12
@@ -91,7 +92,7 @@ steps:
 steps:
   - name: Setup SM_CLIENT_CERT_FILE from base64 secret data
     run: |
-      echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/sm_client_cert.p12
+      echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
       shell: bash
   - name: Setup Software Trust Manager
     uses: digicert/code-signing-software-trust-action@v1


### PR DESCRIPTION
This pull request makes a minor update to the workflow documentation in `README.md` by renaming the output file for the decoded certificate to improve clarity and consistency.

* Updated the output file name in the certificate setup step from `sm_client_cert.p12` to `Certificate_pkcs12.p12` and adjusted the corresponding environment variable to reference the new file name. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R82) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R95)Corrected the certificate file name when writing/appending the certificate from base64 to the file for Windows sample instruction.